### PR TITLE
fix search for ied in dict in get_IED_by_name

### DIFF
--- a/src/scl_loader/scl_loader.py
+++ b/src/scl_loader/scl_loader.py
@@ -1036,7 +1036,7 @@ class SCD_handler():
             `IED`
                 The loaded IED object
         """
-        if hasattr(self._IEDs, ied_name):
+        if ied_name in self._IEDs:
             return self._IEDs[ied_name]
 
         ied_elems = self._get_IED_elems_by_names([ied_name])


### PR DESCRIPTION
The IED should be loaded once and stored in a dict, but the access to the ied dict entries in get_IED_by_name was bugged, and IED were loaded each time. --> massive speed-up with the fix when get_IED_by_name is called several time on the same IED.