### PR TITLE
Manage Private in lists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(path.join(HERE, 'requirements.txt'), encoding='utf-8') as f:
 # Fields marked as "Optional" may be commented out.
 setup(
     name='scl_loader',  # Required
-    version='1.11.5',  # Required
+    version='1.11.6',  # Required
     description='Outil de manipulation de SCD',  # Required
     long_description=LONG_DESCRIPTION,  # Optional
     long_description_content_type='text/markdown',  # Optional (see note above)

--- a/src/scl_loader/scl_loader.py
+++ b/src/scl_loader/scl_loader.py
@@ -19,7 +19,7 @@ REG_DA = r'(?:\{.+\})?[BS]?DA'
 REG_DO = r'(?:\{.+\})?S?DO'
 REG_SDI = r'(?:\{.+\})?S?D[OA]?I'
 REG_ARRAY_TAGS = r'(?:\{.+\})?(?:FCDA|ClientLN|IEDName|FIP|BAP|ExtRef|Terminal|P|DataSet|GSE' \
-                 r'|GSEControl|ReportControl|SampledValueControl|VoltageLevel)'  # |Server)'
+                 r'|GSEControl|ReportControl|SampledValueControl|VoltageLevel|Private)'  # |Server)'
 REG_DT_NODE = r'(?:.*\})?((?:[BS]?D[AO])|(?:LN0?))'
 REF_SCL_NODES = r'(?:\{.+\})?(?:Header|Substation|Private|Communication)'
 DEFAULT_AP = 'PROCESS_AP'


### PR DESCRIPTION
Multiple Private at the same level may have the same type. With this fix, they are managed in an array, so that Private SCDNode are not overridden. 